### PR TITLE
Create MANIFEST that includes license info

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+include README.rst
+include COPYING


### PR DESCRIPTION
Hey-lo,

I'm building a version of `leather` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

Also, if you could see your way to pushing version `0.3.4` to pypi at some point, that would be excellent too. (Currently using the `0.3.3` build.)