### PR TITLE
Include license in sdists and wheels.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include AUTHORS.rst
+include CHANGELOG.rst
+include COPYING
+include README.rst
+include tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[wheel]
+universal = 1
+
+[metadata]
+license_file = COPYING


### PR DESCRIPTION
The license requires that all copies of the software include the license text. These patches make sure sdists and wheels include the license text. Without this, other people cannot legally redistribute the software.