### PR TITLE
import from collections.abc to suppress python 3.7 warning

### DIFF
--- a/leather/series/base.py
+++ b/leather/series/base.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from collections import Iterable, Sequence, Mapping
+try:
+    from collections.abc import Iterable, Sequence, Mapping
+except ImportError:
+    from collections import Iterable, Sequence, Mapping
 from functools import partial
 
 import six

--- a/leather/series/category.py
+++ b/leather/series/category.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from collections import Iterable, Sequence, Mapping
+try:
+    from collections.abc import Iterable, Sequence, Mapping
+except ImportError:
+    from collections import Iterable, Sequence, Mapping
 from functools import partial
 
 import six


### PR DESCRIPTION
`Iterable`, `Sequence`, and `Mapping` should be imported from `collections.abc` instead of `collections` since Python 3.3. A warning is printed starting with Python 3.7 and in Python 3.9 the new import location will be required.

This PR imports from `collections.abc` while still falling back to importing from `collections` for older Python versions.