### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -174,7 +174,7 @@ Chart styles are set using a dead simple :mod:`.theme` system. Leather is meant 
 Changing series colors
 ----------------------
 
-More practically, individual default :class:`.Series` colors can be overriden when they are created.
+More practically, individual default :class:`.Series` colors can be overridden when they are created.
 
 .. literalinclude:: ../examples/series_color.py
     :language: python

--- a/leather/utils.py
+++ b/leather/utils.py
@@ -62,7 +62,7 @@ else:
 
         Via: https://github.com/PythonCHB/close_pep/blob/master/isclose.py
 
-        Verified against final CPython 3.5 implemenation.
+        Verified against final CPython 3.5 implementation.
 
         :param a:
             The first number to check.


### PR DESCRIPTION
There are small typos in:
- docs/examples.rst
- leather/utils.py

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `implementation` rather than `implemenation`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md