### PR TITLE
Use axis_title_font_size and tick_font_size.

### DIFF
--- a/leather/axis.py
+++ b/leather/axis.py
@@ -83,6 +83,7 @@ class Axis(object):
             )
             title.set('text-anchor', 'middle')
             title.set('font-family', theme.axis_title_font_family)
+            title.set('font-size', six.text_type(theme.axis_title_font_size))
             title.text = self._name
 
             group.append(title)
@@ -164,6 +165,7 @@ class Axis(object):
             )
             label.set('text-anchor', text_anchor)
             label.set('font-family', theme.tick_font_family)
+            label.set('font-size', six.text_type(theme.tick_font_size))
 
             value = tick_formatter(value, i, tick_count)
             label.text = six.text_type(value)


### PR DESCRIPTION
Commit c3654820b386e53daab9ea53e43738579fb85f18 added a # of options for axis
titles to theme.py. All of these options are used except for font_size.
Similarly, all theme options for ticks are used except font_size.

This commit uses those properties.

To reproduce ...
```
import leather, math

leather.theme.title_font_size = 40
leather.theme.axis_title_font_size = 40
leather.theme.tick_font_size = 40

chart = leather.Chart("Title")
chart.add_line([(x, math.sin(x)) for x in range(-10,10)])
chart.add_x_axis(name="X Axis")
chart.add_y_axis(name="Y Axis")
print(chart.to_svg())
```

Before ...
![example_before](https://user-images.githubusercontent.com/5589376/167483731-71b2bd44-a574-498f-87dc-773b1ebcff68.svg)

After ... (all text is now the same size)
![example_after](https://user-images.githubusercontent.com/5589376/167483594-ad08b420-f1f5-487d-89a3-34bebe8e4323.svg)

I use `six.text_type` instead of `str` to respect precedent but also keep 2/3 compatibility. 